### PR TITLE
fix(react): Add missing arShadowReceiver prop

### DIFF
--- a/components/ViroPolygon.tsx
+++ b/components/ViroPolygon.tsx
@@ -60,6 +60,7 @@ type Props = {
    * that texture partially over the entire surface.
    */
   uvCoordinates?: ViroUVCoordinate;
+  arShadowReceiver?: boolean
   style?: ViroStyle;
 };
 

--- a/components/ViroQuad.tsx
+++ b/components/ViroQuad.tsx
@@ -18,6 +18,7 @@ import { checkMisnamedProps } from "./Utilities/ViroProps";
 import { ViroBase } from "./ViroBase";
 
 type Props = {
+  arShadowReceiver?: boolean
   uvCoordinates?: ViroUVCoordinate[];
 };
 


### PR DESCRIPTION
According to the documentation for [ViroQuad](https://viro-community.readme.io/docs/viroquad) and [ViroPolygon](https://viro-community.readme.io/docs/viropolygon), they should have an `arShadowReceiver` prop to determine if the component should act as a transparent surface and capture any shadows that are cast onto it.

This, however, is missing from the prop types of the two components, which means TypeScript errors when the components are used with that prop.

This PR adds the prop to the prop type definitions of the two components.